### PR TITLE
fix linux build script

### DIFF
--- a/build-tuner-linux.sh
+++ b/build-tuner-linux.sh
@@ -5,9 +5,10 @@ JRI="${HOME}${R_LIBS_USER#\~}/rJava/jri"
 R_HOME=`R RHOME`
 export R_HOME
 
+test -d date-scala || \
 git clone https://bitbucket.org/gabysbrain/date.scala.git date-scala
 
 java -Xmx512M "-Djava.library.path=$JRI" -jar sbt-launch.jar assembly \
-	&& mv target/Tuner-assembly-0.9.jar  .
+	&& mv target/scala*/Tuner-assembly-*.jar  .
 
 


### PR DESCRIPTION
The Tuner-assembly .jar is in a different position, and
the data-scala cloning can be skipped if the directory is present.
