### PR TITLE
Fix Windows preferences path

### DIFF
--- a/src/main/scala/tuner/Tuner.scala
+++ b/src/main/scala/tuner/Tuner.scala
@@ -40,11 +40,10 @@ object Tuner extends SimpleSwingApplication {
   // Serializers to get the json parser to work
   implicit val formats = net.liftweb.json.DefaultFormats
 
-  val prefsPath = System.getProperty("user.home") + (OS.detect match {
-    case OS.Mac  => "/Library/Preferences/at.ac.univie.cs.tuner.json"
-    case OS.Win  => "\\" + System.getenv("APPDATA") + 
-                    "\\UniVie Software\\Tuner\\prefs.json"
-    case OS.Unix => "/.univie.tuner.json"
+  val prefsPath = (OS.detect match {
+    case OS.Mac  => System.getProperty("user.home") + "/Library/Preferences/at.ac.univie.cs.tuner.json"
+    case OS.Win  => System.getenv("APPDATA") + "\\UniVie Software\\Tuner\\prefs.json"
+    case OS.Unix => System.getProperty("user.home") + "/.univie.tuner.json"
   })
 
   private def savePrefs(p:TunerPrefs) = {


### PR DESCRIPTION
Maybe it's just on my Windows 7 box and its different on other Windows versions, but here I got an error when trying to start Tuner 0.10.2:

```
Exception in thread "main" java.lang.ExceptionInInitializerError
        at tuner.Tuner.main(Tuner.scala)
Caused by: java.io.FileNotFoundException: C:\Users\xyz\C:\Users\xyz\AppData\Roaming\UniVie Software\Tuner\prefs.json (Die Syntax für den Dateinamen, Verzeichnisnamen oder die Datenträgerbezeichnung ist falsch)
```

This pull request fixes this for me (hopefully without breaking it for other OSes, haven't had the opportunity to check yet).
